### PR TITLE
Update `name` and `about` for the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,6 +1,6 @@
 ---
-name: Bug Report
-about: Describe this issue template's purpose here.
+name: Bug report
+about: Submit a bug report
 title: ""
 labels: midnight-template-repo, public
 assignees: ""

--- a/.github/ISSUE_TEMPLATE/documentation-improvement.md
+++ b/.github/ISSUE_TEMPLATE/documentation-improvement.md
@@ -1,6 +1,6 @@
 ---
-name: Documentation Improvement
-about: Describe this issue template's purpose here.
+name: Documentation improvement
+about: Report a problem with the documentation
 title: ""
 labels: midnight-template-repo, public
 assignees: ""

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,6 +1,6 @@
 ---
-name: Feature Request
-about: Describe this issue template's purpose here.
+name: Feature request
+about: Submit a proposal for a new Midnight template repository feature
 title: ""
 labels: midnight-template-repo, public
 assignees: ""

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Submit a proposal for a new Midnight template repository feature
+about: Submit a proposal for a new feature
 title: ""
 labels: midnight-template-repo, public
 assignees: ""


### PR DESCRIPTION
The `name` and `about` metadata is used to populate the issue chooser when a user files a new issue.  Update these to be consistent and informative:

- The names use "Initial capitals" to be consistent with "Blank issue" and "Report a security vulnerability" which are prepopulated in the issue chooser.

- Add informative descriptions, parallel in structure to the default ones and without a trailing period for consistency with the default ones