### PR TITLE
feat: be explicit about licensing rules in the contribution.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,26 @@ Ensure the title is a clear summary of the requirement and provides enough conte
 * **Coding Standards:** Code must adhere to the coding style guides defined in our documentation
 * **Testing:** New functionality must include corresponding unit tests and integration tests.
 * **Documentation:** Code changes should be accompanied by proposed relevant documentation updates.
-* **License:** All contributions must be compatible with the project's license.
+* **License:** All contributions must be compatible with the project's license. Where possible all files should have this license header:
+
+```
+ <I>// This file is part of <B>REPLACE WITH REPO-NAME</B>.<BR>
+ // Copyright (C) 2025 Midnight Foundation<BR>
+ // SPDX-License-Identifier: Apache-2.0<BR>
+ // Licensed under the Apache License, Version 2.0 (the "License");<BR>
+ // You may not use this file except in compliance with the License.<BR>
+ // You may obtain a copy of the License at<BR>
+ //<BR>
+ //	http://www.apache.org/licenses/LICENSE-2.0<BR>
+ //<BR>
+ // Unless required by applicable law or agreed to in writing, software<BR>
+ // distributed under the License is distributed on an "AS IS" BASIS,<BR>
+ // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.<BR>
+ // See the License for the specific language governing permissions and<BR>
+ // limitations under the License.</I>
+```
+
+Where this is not possible, a LICENSE.md file in the same dir is required.
 
 ## Support and Communication:
 


### PR DESCRIPTION
We don't say each file should have a SPDX-License-Identifier in the contribution.md at the moment. We're not expecting people to keep the SPDX-License-Identifier in the readme.md so we should be explicit here. 