### PR TITLE
feat: know to sign commits earlier

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+# point out to users at commit time that commits need to be signed,
+# not once they've done many commits and are trying to push a PR:
+git config --local commit.gpgSign true
+git config --local tag.gpgSign true


### PR DESCRIPTION
Assuming `direnv allow` is run, this will ensure that a user cloning the repo knows that signed commits are expected.

It's not possible to check in changes to `./.git/config` files, so this is the closest we can come. It takes no time and works even with my nix locked down global git config.

Otherwise we have to turn people away at the PR raising point saying that's nice but can you sign your commits please?