### PR TITLE
feat: force commits bad

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,19 +24,24 @@ Ensure the title is a clear summary of the requirement and provides enough conte
 
 * **Pull Requests:** Code contributions are submitted via Pull Requests.
 * **Fork the Repository:** Create your own fork of the Midnight repository.
-* **Create a Branch:** Make your changes in a separate branch.
+* **Create a Branch:** Make your changes in a separate branch,
+  prefixed with a short name moniker (e.g. `jill-my-feature`).
 * **Follow Coding Standards:** Adhere to the coding style guides specified in our documentation.
 * **Write Tests:** Include unit tests and integration tests to cover your changes.
 * **Commit Messages:** Write clear and concise commit messages.
 * **Submit Pull Request:** Submit your pull request to the appropriate branch in the main repository.
-* **Code Review:** All pull requests undergo code review by project maintainers. Be prepared to address feedback from reviewers.
+* **Please do not `--force` pushes** - doing so means that reviewers will have to re-review all
+  commits in the PR rather than commits since last review.
+* **Code Review:** All pull requests undergo code review by project maintainers.
+  Be prepared to address feedback from reviewers.
 
 ## Requirements for Acceptable Contributions:
 
 * **Coding Standards:** Code must adhere to the coding style guides defined in our documentation
 * **Testing:** New functionality must include corresponding unit tests and integration tests.
 * **Documentation:** Code changes should be accompanied by proposed relevant documentation updates.
-* **License:** All contributions must be compatible with the project's license. Where possible all files should have this license header:
+* **License:** All contributions must be compatible with the project's license.
+  Where possible all files should have this license header:
 
 ```
 // This file is part of <REPLACE WITH REPOSITORY NAME>.


### PR DESCRIPTION
It's pretty clear why force commits in PRs are undesirable (especially as we squash PRs).

It's less obvious why branch name `jill-my-feature` is better than `jill/my-feature`:

"both one/two and one/two/three are valid branch names, but you can't have both in the same repo. Due to the way branches are represented in the .git directory tree, that would require one/two to be both a regular file and a directory."
( https://stackoverflow.com/questions/68009994/why-do-some-git-branch-names-have-slashes-in-them )

Aside from that added a couple of newlines so that there's not so many long lines.