### PR TITLE
fix: don't fail workflow if repo is not yet public

### DIFF
--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -93,6 +93,7 @@ jobs:
 
       # Upload report so security issues are viewable from within the github ui
       - name: Upload SARIF file
+        if: ${{ github.event.repository.private == false }}
         uses: github/codeql-action/upload-sarif@4e20239e7b23c6078c563635c41d109adaaa1f72  # v3.29.2
         with:
           sarif_file: cx_result.sarif


### PR DESCRIPTION
private repos would fail this step