### PR TITLE
fix: fix rather than filter non-uploading issues.

### DIFF
--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: Filter out repo level issues that github can't handle
         run: |
           mv ./cx_result.sarif ./cx_result.sarif.orig
-          jq '. | .runs[0].results |= map(select(.locations[0].physicalLocation.artifactLocation.uri != ""))' cx_result.sarif.orig > cx_result.sarif
+          jq '.runs |= map(.results |= map(.locations |= map(if .physicalLocation.artifactLocation.uri == "" then .physicalLocation.artifactLocation.uri = "file:/README.md" else . end)))' cx_result.sarif.orig > cx_result.sarif
 
       # Upload report so security issues are viewable from within the github ui
       - name: Upload SARIF file


### PR DESCRIPTION
https://github.com/midnightntwrk/midnight-node-docker/pull/32

Now rather than filtering out events that won't upload we can fix them so they do upload by giving them a dummy file - E.g: this is an alert that now gets passed through: https://github.com/midnightntwrk/midnight-node-docker/security/code-scanning/45