### PR TITLE
feat: use action

### DIFF
--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -33,11 +33,11 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           repository: midnightntwrk/upload-sarif-github-action
-          ref: 20eb09abe9113be23e3791b5298c120ce15a95a5
+          ref: 46581f193c493f6bf464cca059dd7f4238307373
           path: upload-sarif-github-action
           token: ${{ secrets.MIDNIGHTCI_REPO }}
 
-      # Once public, can simplify to: uses: midnightntwrk/upload-sarif-github-action/checkmarx-scan@20eb09abe9113be23e3791b5298c120ce15a95a5
+      # Once public, can simplify to: uses: midnightntwrk/upload-sarif-github-action/checkmarx-scan@46581f193c493f6bf464cca059dd7f4238307373
       - name: Checkmarx Full Scan
         uses: ./upload-sarif-github-action/checkmarx-scan
         with:

--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -33,11 +33,11 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           repository: midnightntwrk/upload-sarif-github-action
-          ref: 78abd6e4c6b7d15715ab641fff5ed6fa4751dd53
+          ref: 0b4ad9b5eba2b43e18a969aee2b8518d8af6a68e
           path: upload-sarif-github-action
           token: ${{ secrets.MIDNIGHTCI_REPO }}
 
-      # Once public, can simplify to: uses: midnightntwrk/upload-sarif-github-action/checkmarx-scan@46581f193c493f6bf464cca059dd7f4238307373
+      # Once public, can simplify to: uses: midnightntwrk/upload-sarif-github-action/checkmarx-scan@0b4ad9b5eba2b43e18a969aee2b8518d8af6a68e
       - name: Checkmarx Full Scan
         uses: ./upload-sarif-github-action/checkmarx-scan
         with:

--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           repository: midnightntwrk/upload-sarif-github-action
-          ref: 46581f193c493f6bf464cca059dd7f4238307373
+          ref: 78abd6e4c6b7d15715ab641fff5ed6fa4751dd53
           path: upload-sarif-github-action
           token: ${{ secrets.MIDNIGHTCI_REPO }}
 

--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -25,75 +25,24 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  #v5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install beautifulsoup4 requests
-
-      - name: Scrape Checkmarx status
-        run: |
-          cat <<'EOF' > scrape_checkmarx.py
-          import requests
-          from bs4 import BeautifulSoup
-
-          # URL of the status page
-          url = "https://eu2-status.ast.checkmarx.net/"
-
-          try:
-              # Send a GET request to fetch the HTML content
-              response = requests.get(url)
-              response.raise_for_status()  # Check for request errors
-
-              # Parse the HTML content
-              soup = BeautifulSoup(response.text, 'html.parser')
-
-              # Locate the status element based on its HTML structure
-              status_element = soup.find('aside', class_='operational state-bar')
-
-              # Check if the status is operational
-              if status_element and 'Operating Normally' in status_element.text:
-                  print("The status is operational with status")
-                  print(status_element.text)
-              else:
-                  print("The status is not operational.")
-          except requests.exceptions.RequestException as e:
-              print(f"An error occurred: {e}")
-          EOF
-          python3 scrape_checkmarx.py
-
-      - name: Check Checkmarx One server health
-        run: |
-          response=$(curl -s -o /dev/null -w "%{http_code}" https://ind-status.ast.checkmarx.net/)
-          if [ "$response" != "200" ]; then
-            echo "Checkmarx One server is down. Proceeding without breaking the build."
-            exit 0  # Do not fail the build
-          else
-            echo "Checkmarx One server is healthy. Proceeding with scan."
-          fi
-
-      - name: Checkmarx One CLI Action
-        uses: checkmarx/ast-github-action@ef313c2c19e03e90ae35e795724fb1d20830dc33 #2.3.26
+      # TODO: Remove this checkout step once upload-sarif-github-action repo is made public
+      # Currently required because GitHub Actions can't directly reference private repos
+      - name: Checkout Upload action repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
-          cx_tenant: ${{ secrets.CX_TENANT }}
-          base_uri: https://eu-2.ast.checkmarx.net/
-          cx_client_id: ${{ secrets.CX_CLIENT_ID }}
-          cx_client_secret: ${{ secrets.CX_CLIENT_SECRET_EU }}
-          additional_params: >
-            --scs-repo-url https://github.com/${{ github.repository }}
-            --scs-repo-token ${{ secrets.MIDNIGHTCI_REPO }}
-            --report-format sarif
+          repository: midnightntwrk/upload-sarif-github-action
+          ref: 20eb09abe9113be23e3791b5298c120ce15a95a5
+          path: upload-sarif-github-action
+          token: ${{ secrets.MIDNIGHTCI_REPO }}
 
-      # if artifactLocation is empty github will fail the whole import
-      - name: Filter out repo level issues that github can't handle
-        run: |
-          mv ./cx_result.sarif ./cx_result.sarif.orig
-          jq '.runs |= map(.results |= map(.locations |= map(if .physicalLocation.artifactLocation.uri == "" then .physicalLocation.artifactLocation.uri = "file:/README.md" else . end)))' cx_result.sarif.orig > cx_result.sarif
-
-      # Upload report so security issues are viewable from within the github ui
-      - name: Upload SARIF file
-        if: ${{ github.event.repository.private == false }}
-        uses: github/codeql-action/upload-sarif@5b49155c7f37b5ec074ffd26b428e6b64b1bf412  # v3.29.2
+      # Once public, can simplify to: uses: midnightntwrk/upload-sarif-github-action/checkmarx-scan@20eb09abe9113be23e3791b5298c120ce15a95a5
+      - name: Checkmarx Full Scan
+        uses: ./upload-sarif-github-action/checkmarx-scan
         with:
-          sarif_file: cx_result.sarif
+          cx-client-id: ${{ secrets.CX_CLIENT_ID }}
+          cx-client-secret: ${{ secrets.CX_CLIENT_SECRET_EU }}
+          cx-tenant: ${{ secrets.CX_TENANT }}
+          scs-repo-token: ${{ secrets.MIDNIGHTCI_REPO }}
+          upload-to-github: 'true'


### PR DESCRIPTION
Rather than having the guts of how we use checkmarx sprawled everywhere and updated piecemeal, we have packaged it up into a reusable action that can be called. This way dependabot / renovate can raise PRs to upgrade repos to use the latest version rather than it being 100% manual.