### PR TITLE
feat: set default cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,22 +5,30 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      
+    cooldown:
+      default-days: 7
+
 #  - package-ecosystem: "cargo"
 #    directory: "/"
 #    registries: "*"
 #    schedule:
 #      interval: "daily"
+#    cooldown:
+#      default-days: 7
 #
 #  - package-ecosystem: "npm"
 #    directory: "/"
 #    schedule:
 #      interval: "daily"
+#    cooldown:
+#      default-days: 7
 #
 #  - package-ecosystem: "docker"
 #    directory: "/"
 #    schedule:
 #      interval: "weekly"
+#    cooldown:
+#      default-days: 7
 #
 #registries:
 #   github:


### PR DESCRIPTION
Set safer defaults.
(note: unlike renovate, dependabot has no way to pull in config from other repos)